### PR TITLE
Replace ereg_replace with preg_replace for PHP compatibility

### DIFF
--- a/classes/class-hosting.php
+++ b/classes/class-hosting.php
@@ -15,8 +15,8 @@
 
 			$results = $hosting_html->find('div[id=ip_info_inside-dbip]', 0);
 
-			$results = ereg_replace('/images', 'images', $results);
-			$results = ereg_replace('class="hostinfo result', 'class="table table-striped table-sm', $results);
+			$results = preg_replace('#\/images#i', 'images', $results);
+			$results = preg_replace('#class="hostinfo resultg#i', 'class="table table-striped table-sm', $results);
 
 			return $results;
 


### PR DESCRIPTION
This threw errors and didn't work with PHP 5.6 
```
Deprecated: Function ereg_replace() is deprecated in /home3/vmanthos78/public_html/rocket-hangar/classes/class-hosting.php on line 18
Deprecated: Function ereg_replace() is deprecated in /home3/vmanthos78/public_html/rocket-hangar/classes/class-hosting.php on line 19
```