### PR TITLE
Use the "Rocket" class where applicable.

### DIFF
--- a/index.php
+++ b/index.php
@@ -71,11 +71,12 @@ if ($url) :
    // wprocket - enabled options
   $widget = new widget;
   $rocket = new Rocket( $site_html, $url );
-  $features_enabled = $rocket->features_enabled;
   $widget_body = '';
   if( $rocket->is_wpr_installed ){
-	  foreach( $features_enabled as $feature_enabled){
-		  $widget_body .= $feature_enabled . '<br>';
+		$features_enabled = $rocket->enabled_features;
+
+		foreach( $features_enabled as $feature ){
+			$widget_body .= $feature . '<br>';
 		}
   } else {
 	  $widget_body = 'Oops! WP Rocket is not installed!<br>';


### PR DESCRIPTION
I didn't add the inline JavaScript part. That probably should not be in a widget because of the amount of text involved.

Also, the same could apply to JavaScript and CSS files. In some sites, there will be long lists of files which could mess the way the dashboard looks.